### PR TITLE
[218] external-dns: cannot use module with exisiting hostedZone

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ``` hcl
 module external_dns {
   source       = "github.com/provectus/sak-external-dns"
-  cluster_name = module.kubernetes.cluster_name
+  cluster_name = module.eks.cluster_id
   argocd       = module.argocd.state
   hostedzones  = ["your.hosted.zones"]     # Provide your hosted zones (description in Input section)
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 # External DNS
 ## Example
+### Create public or private hostedzone
+
 ``` hcl
 module external_dns {
   source       = "github.com/provectus/sak-external-dns"
   cluster_name = module.eks.cluster_id
   argocd       = module.argocd.state
-  hostedzones  = ["your.hosted.zones"]     # Provide your hosted zones (description in Input section)
+  hostedzones  = ["your.hosted.zones"]
+  aws_private  = true
 }
 ```
+- aws_private is a boolean variable accepting inputs: true or false. Meaning it will either create a private or public hostedzone
+
+### Create DNS using an existing hostedzone
+
+``` hcl
+module external_dns {
+  source       = "github.com/provectus/sak-external-dns"
+  cluster_name = module.eks.cluster_id
+  argocd       = module.argocd.state
+  hostedzones  = ["your.hosted.zones"]
+  mainzoneid   = "your-existing-zone-id"
+}
+```
+
 ## Requirements
 
 ```

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "ns" {
 }
 
 resource "aws_route53_zone" "public" {
-  count = var.aws_private == false && var.mainzoneid == "" ? length(var.hostedzones) : 0
+  count = var.aws_private != true ? length(var.hostedzones) : 0
   name  = element(var.hostedzones, count.index)
 
   tags          = var.tags
@@ -69,7 +69,7 @@ resource "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_zone" "private" {
-  count = var.aws_private == true && var.mainzoneid == "" ? length(var.hostedzones) : 0
+  count = var.aws_private == true ? length(var.hostedzones) : 0
   name  = element(var.hostedzones, count.index)
   vpc {
     vpc_id = var.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "ns" {
 }
 
 resource "aws_route53_zone" "public" {
-  count = var.mainzoneid == "" ? length(var.hostedzones) : 0
+  count = var.aws_private == false && var.mainzoneid == "" ? length(var.hostedzones) : 0
   name  = element(var.hostedzones, count.index)
 
   tags          = var.tags
@@ -69,8 +69,8 @@ resource "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_zone" "private" {
-  count = var.mainzoneid == "" ? 0 : length(var.hostedzones)
-  name  = var.mainzoneid != "" ? var.mainzoneid : element(var.hostedzones, count.index)
+  count = var.aws_private == true && var.mainzoneid == "" ? length(var.hostedzones) : 0
+  name  = element(var.hostedzones, count.index)
   vpc {
     vpc_id = var.vpc_id
   }

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "ns" {
 }
 
 resource "aws_route53_zone" "public" {
-  count = var.create_zone ? (var.aws_private ? 0 : length(var.hostedzones)) : 0
+  count = var.mainzoneid == "" ? length(var.hostedzones) : 0
   name  = element(var.hostedzones, count.index)
 
   tags          = var.tags
@@ -69,8 +69,8 @@ resource "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_zone" "private" {
-  count = var.create_zone ? (var.aws_private ? length(var.hostedzones) : 0) : 0
-  name  = element(var.hostedzones, count.index)
+  count = var.mainzoneid == "" ? 0 : length(var.hostedzones)
+  name  = var.mainzoneid != "" ? var.mainzoneid : element(var.hostedzones, count.index)
   vpc {
     vpc_id = var.vpc_id
   }

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ resource "aws_route53_record" "ns" {
 }
 
 resource "aws_route53_zone" "public" {
-  count = var.aws_private ? 0 : length(var.hostedzones)
+  count = var.create_zone ? (var.aws_private ? 0 : length(var.hostedzones)) : 0
   name  = element(var.hostedzones, count.index)
 
   tags          = var.tags
@@ -69,7 +69,7 @@ resource "aws_route53_zone" "public" {
 }
 
 resource "aws_route53_zone" "private" {
-  count = var.aws_private ? length(var.hostedzones) : 0
+  count = var.create_zone ? (var.aws_private ? length(var.hostedzones) : 0) : 0
   name  = element(var.hostedzones, count.index)
   vpc {
     vpc_id = var.vpc_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "zone_id" {
-  value = var.mainzoneid != "" ? var.mainzoneid : (var.aws_private == true ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id)
+  value       = var.mainzoneid != "" ? var.mainzoneid : (var.aws_private == true ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id)
   description = "An ID of the created Route53 zone"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "zone_id" {
-  value       = var.aws_private == "true" ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id
+  value = var.mainzoneid != "" ? var.mainzoneid : (var.aws_private ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id)
   description = "An ID of the created Route53 zone"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "zone_id" {
-  value = var.mainzoneid != "" ? var.mainzoneid : (var.aws_private ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id)
+  value = var.mainzoneid != "" ? var.mainzoneid : (var.aws_private == true ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id)
   description = "An ID of the created Route53 zone"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -69,9 +69,3 @@ variable "vpc_id" {
   default     = null
   description = "An ID of the existing AWS VPC"
 }
-
-variable "create_zone" {
-  type        = bool
-  default     = true
-  description = "Set true or false to create new zone or use existing one"
-}

--- a/variables.tf
+++ b/variables.tf
@@ -69,3 +69,7 @@ variable "vpc_id" {
   default     = null
   description = "An ID of the existing AWS VPC"
 }
+
+variable "create_zone" {
+  default = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -71,5 +71,7 @@ variable "vpc_id" {
 }
 
 variable "create_zone" {
-  default = true
+  type        = bool
+  default     = true
+  description = "Set true or false to create new zone or use existing one"
 }


### PR DESCRIPTION
aws_route53_zone resources will be created only if the mainzoneid variable is provided and create_zone variable is set to true, otherwise the existing zone is used

The error that was presented when using mainzoneid variable:

```
Error: Invalid index
on .terraform/modules/external_dns/outputs.tf line 2, in output "zone_id":
2:   value       = var.aws_private == "true" ? aws_route53_zone.private[0].zone_id : aws_route53_zone.public[0].zone_id
aws_route53_zone.public is empty tuple
```
How module was used successfully after implementing changes in PR:
```
module "external_dns" {
  source       = "github.com/pvlbnkl/sak-external-dns"
  cluster_name = module.eks.cluster_id
  argocd       = module.argocd.state
  mainzoneid   = "Z020452411YL6ISW5A1GW"
}
```
